### PR TITLE
refacto api url injection

### DIFF
--- a/client/src/config/api/api.spec.ts
+++ b/client/src/config/api/api.spec.ts
@@ -1,8 +1,0 @@
-import { apiConfig } from './api'
-
-test('config should defined some const', () => {
-  expect(apiConfig.url).toBeDefined()
-  expect(apiConfig.url.local).toBeDefined()
-  expect(apiConfig.url.integration).toBeDefined()
-  expect(apiConfig.url.production).toBeDefined()
-})

--- a/client/src/config/api/api.ts
+++ b/client/src/config/api/api.ts
@@ -1,7 +1,0 @@
-export const apiConfig: any = {
-  url: {
-    local: 'http://localhost:3030',
-    integration: 'https://emendare-api-integration.cleverapps.io',
-    production: 'https://emendare-api.cleverapps.io'
-  }
-}

--- a/client/src/config/api/index.ts
+++ b/client/src/config/api/index.ts
@@ -1,1 +1,0 @@
-export * from './api'

--- a/client/src/config/index.ts
+++ b/client/src/config/index.ts
@@ -1,2 +1,1 @@
-export * from './api'
 export * from './routes'

--- a/client/src/services/socket/socket.ts
+++ b/client/src/services/socket/socket.ts
@@ -2,7 +2,9 @@ import io from 'socket.io-client'
 import { apiConfig } from '../../config'
 
 // Default Socket.io Instance
-const insecureSocket = io(apiConfig.url[process.env.DEPLOY_ENV || 'local'])
+const insecureSocket = io(
+  apiConfig.url[process.env.REACT_APP_API_URL || 'http://localhost:3030']
+)
 
 // Overwrited Socket.io Instance
 // With fetch method and token prop

--- a/client/src/services/socket/socket.ts
+++ b/client/src/services/socket/socket.ts
@@ -1,9 +1,8 @@
 import io from 'socket.io-client'
-import { apiConfig } from '../../config'
 
 // Default Socket.io Instance
 const insecureSocket = io(
-  apiConfig.url[process.env.REACT_APP_API_URL || 'http://localhost:3030']
+  process.env.REACT_APP_API_URL || 'http://localhost:3030'
 )
 
 // Overwrited Socket.io Instance


### PR DESCRIPTION
Use env variables to pass api url for staging and production instances